### PR TITLE
use single commit for github pages deploy action

### DIFF
--- a/.github/workflows/examples_on_main.yaml
+++ b/.github/workflows/examples_on_main.yaml
@@ -69,6 +69,7 @@ jobs:
         commit-message: https://github.com/databasedav/haalka/commit/${{ github.sha }}
         folder: pages
         force: false
+        single-commit: true
         target-folder: examples
   get_examples_:
     name: get_examples_

--- a/.github/workflows/pr_previews.yaml
+++ b/.github/workflows/pr_previews.yaml
@@ -69,6 +69,7 @@ jobs:
         commit-message: https://github.com/databasedav/haalka/pull/${{ github.event.number }}/commits/${{ github.event.pull_request.head.sha }}
         folder: pages
         force: false
+        single-commit: true
         target-folder: pr_previews/${{ github.event.number }}
   deployment_comment:
     name: deployment_comment

--- a/kaaj/src/common.ncl
+++ b/kaaj/src/common.ncl
@@ -157,6 +157,7 @@ let install_nickel_ = {
             attempt-limit = GITHUB_PAGES_DEPLOY_ACTION_ATTEMPT_LIMIT,
             target-folder = if pr != "" then "pr_previews/%{ pr }" else "examples",
             commit-message = if pr != "" then "%{ REPO }/pull/%{ pr }/commits/${{ github.event.pull_request.head.sha }}" else "%{ REPO }/commit/${{ github.sha }}",
+            single-commit = true,
           }
         },
       ]


### PR DESCRIPTION
should prevent objects from piling up in and exploding the repo size a la https://github.com/databasedav/haalka/issues/20