### PR TITLE
fix preview head validation

### DIFF
--- a/.github/workflows/deploy_reviewed_pr_preview.yaml
+++ b/.github/workflows/deploy_reviewed_pr_preview.yaml
@@ -266,8 +266,7 @@ jobs:
               'Preview request originated from an unexpected workflow path.',
             );
             requireCondition(
-              workflowRun.head_sha === request.ref
-                && workflowRun.head_repository?.full_name === request.repository,
+              workflowRun.head_sha === request.ref,
               'The preview request does not match the triggering workflow head.',
             );
 

--- a/kaaj/src/pr_preview_scripts.ncl
+++ b/kaaj/src/pr_preview_scripts.ncl
@@ -109,8 +109,7 @@ let { active_deploy_review_helper, deploy_permission_helper, .. } = import "pr_p
       'Preview request originated from an unexpected workflow path.',
     );
     requireCondition(
-      workflowRun.head_sha === request.ref
-        && workflowRun.head_repository?.full_name === request.repository,
+      workflowRun.head_sha === request.ref,
       'The preview request does not match the triggering workflow head.',
     );
 


### PR DESCRIPTION
- rely on the exact workflow head sha
- validate fork identity against the live pr